### PR TITLE
adds support for using acl to secure communication to consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk --update add nodejs git openssh curl bash inotify-tools jq && \
     mkdir -p /etc/git2consul.d
 
 ADD load-config.sh /
+ADD jhi-acl.json /
 VOLUME /config
 
 ENV CONFIG_MODE=filesystem
@@ -14,5 +15,7 @@ ENV INIT_SLEEP_SECONDS=5
 ENV CONSUL_URL=localhost
 ENV CONSUL_PORT=8500
 ENV CONFIG_DIR=/config
+ENV MASTER_ACL_TOKEN=to-change-in-production
+ENV CLIENT_ACL_TOKEN=to-change-in-production-client
 
 CMD /load-config.sh

--- a/jhi-acl.json
+++ b/jhi-acl.json
@@ -1,0 +1,17 @@
+{
+  "ID" : "to-change-in-production-client",
+  "Name": "jhipster-client-acl",
+  "Type": "client",
+  "Rules": "{
+    \"key\" : {
+      \"\": {
+        \"policy\": \"read\"
+      }
+    },
+    \"service\": {
+      \"\": {
+        \"policy\": \"write\"
+      }
+    }
+  }"
+}


### PR DESCRIPTION
assumes a consul server running with ACL enabled and a given master acl token and a (future) client ACL token. 

With this PR, the config loader first creates a client ACL using the name provided in client acl token, and syncs the config with the master token. In the default configuration, the client ACL gets permission to write to services, and to read to KV. This policy can be overwriten by developer.
