### PR TITLE
Maintainer instruction is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.12
-MAINTAINER Pierre Besson https://github.com/PierreBesson
+LABEL maintainer="Pierre Besson https://github.com/PierreBesson"
 
 RUN apk --update add nodejs npm git openssh curl bash inotify-tools jq && \
     rm -rf /var/cache/apk/* && \


### PR DESCRIPTION
Docker "Maintainer" instruction is deprecated.
See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated for more information.
Thanks a lot for your useful project !