### PR TITLE
chore: Update images, fix warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/copyright-update.yml
+++ b/.github/workflows/copyright-update.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 40
     steps:
       # Checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
           grep -rlZE "Copyright ([0-9]+)-$CURRENT_YEAR" . | xargs -0 sed -i -E "s/Copyright ([0-9]+)-$CURRENT_YEAR/Copyright \1-$NEW_YEAR/g"
       # Create PR
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'Update copyright headers'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM alpine:3.12
+FROM alpine:3.19.0
 LABEL maintainer="Pierre Besson https://github.com/PierreBesson"
 
-RUN apk --update add nodejs npm git openssh curl bash inotify-tools jq && \
-    rm -rf /var/cache/apk/* && \
-    npm install -g simplywatch@2.5.7 && \
-    npm install -g git2consul@0.12.13 && \
+RUN apk --update --no-cache add nodejs npm git openssh curl bash inotify-tools jq && \
+    npm install -g \
+      simplywatch@2.5.7 \
+      git2consul@0.12.13 && \
     mkdir -p /etc/git2consul.d
 
-ADD /load-config.sh /
-ADD /upload-consul-file.sh /
+COPY load-config.sh upload-consul-file.sh /
 VOLUME /config
 
 ENV CONFIG_MODE=filesystem
@@ -19,4 +18,4 @@ ENV CONFIG_DIR=/config
 ENV ENABLE_SPRING=true
 ENV ENABLE_MICRONAUT=false
 
-CMD /load-config.sh
+CMD ["/load-config.sh"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A small docker based tool to load Spring Boot and/or Micronaut property files in
 ## Enabling Spring Boot and Micronaut support
 
 Both Spring Boot and Micronaut frameworks are supported, and by default only Spring Boot is enabled.
-To control the compatibility for each framework you should use the following environnement variables: `ENABLE_SPRING` and `ENABLE_MICRONAUT`, with values `true` or `false`.
+To control the compatibility for each framework you should use the following environment variables: `ENABLE_SPRING` and `ENABLE_MICRONAUT`, with values `true` or `false`.
 
 ## Filesystem mode
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'Ubuntu 16.04'
+  vmImage: 'Ubuntu 22.04'
 
 steps:
 - bash: docker build -t jhipster/consul-config-loader:travis .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '2'
+version: '3'
 services:
     consul:
-        image: consul:1.8.3
+        image: consul:1.15
         ports:
-            - 8300:8300
-            - 8500:8500
-            - 8600:8600
+            - "8300:8300"
+            - "8500:8500"
+            - "8600:8600"
         command: consul agent -dev -ui -client 0.0.0.0
 
     consul-config-loader:

--- a/load-config.sh
+++ b/load-config.sh
@@ -2,15 +2,15 @@
 
 # To use outside of docker, set the following environment variables
 # export INIT_SLEEP_SECONDS=0;export CONFIG_MODE=filesystem;export CONFIG_DIR=config/;export CONSUL_URL=localhost;export CONSUL_PORT=8500
-sleep $INIT_SLEEP_SECONDS
+sleep "$INIT_SLEEP_SECONDS"
 
 echo "----------------------------------------------------------------------
     Starting Consul Config Loader in $CONFIG_MODE mode"
 
 function loadPropertiesFilesIntoConsul {
-  for file in $CONFIG_DIR/*."${CONFIG_FORMAT:-yml}"
+  for file in "$CONFIG_DIR"/*."${CONFIG_FORMAT:-yml}"
 	do
-	  /upload-consul-file.sh $file
+	  /upload-consul-file.sh "$file"
 	done
   echo "   Consul Config reloaded"
 }
@@ -42,15 +42,15 @@ if [[ "$CONFIG_MODE" == "git" ]]; then
 	echo "----------------------------------------------------------------------
    Loading configuration in Consul K/V Store from a git repository using git2consul"
 	printf "      git_url          : "
-  cat $CONFIG_DIR/git2consul.json | jq  '.repos[0].url'
+  jq '.repos[0].url' < "$CONFIG_DIR"/git2consul.json
 	printf "      branch(es)       : "
-  cat $CONFIG_DIR/git2consul.json | jq  '.repos[0].branches[]'
+  jq '.repos[0].branches[]' < "$CONFIG_DIR"/git2consul.json
 	printf "      source_root      : "
-  cat $CONFIG_DIR/git2consul.json | jq  '.repos[0].source_root'
+  jq '.repos[0].source_root' < "$CONFIG_DIR"/git2consul.json
 	printf "      polling_interval : "
-  cat $CONFIG_DIR/git2consul.json | jq  '.repos[0].hooks[].interval'
+  jq '.repos[0].hooks[].interval' < "$CONFIG_DIR"/git2consul.json
 
 	echo "   Consul UI: http://$CONSUL_URL:$CONSUL_PORT/ui/#/dc1/kv/config/
 ----------------------------------------------------------------------"
-	git2consul --config-file $CONFIG_DIR/git2consul.json -e $CONSUL_URL -p $CONSUL_PORT
+	git2consul --config-file "$CONFIG_DIR"/git2consul.json -e "$CONSUL_URL" -p "$CONSUL_PORT"
 fi

--- a/upload-consul-file.sh
+++ b/upload-consul-file.sh
@@ -4,11 +4,11 @@ file="$1"
 filename=$(basename $file)
 app=${filename%.*}
 if [[ "$ENABLE_SPRING" == "true" ]]; then
-  curl  --output /dev/null -sX PUT --data-binary @$file http://$CONSUL_URL:$CONSUL_PORT/v1/kv/config/$app/data
+  curl --output /dev/null -sX PUT --data-binary @"$file" "http://$CONSUL_URL:$CONSUL_PORT/v1/kv/config/$app/data"
   echo "   $file uploaded to Consul in Spring mode"
 fi
 
 if [[ "$ENABLE_MICRONAUT" == "true" ]]; then
-  curl  --output /dev/null -sX PUT --data-binary @$file http://$CONSUL_URL:$CONSUL_PORT/v1/kv/config/$app
+  curl --output /dev/null -sX PUT --data-binary @"$file" "http://$CONSUL_URL:$CONSUL_PORT/v1/kv/config/$app"
   echo "   $file uploaded to Consul in Micronaut mode"
 fi


### PR DESCRIPTION
* Update Docker images and OS packages to fix 169 CVEs
* Let Dependabot update Docker images and GitHub Actions
* Fix warnings and typos

Even npm update wasn't able to reduce dozens of CVEs in dependencies of those very old packages, please switch to newer libraries if you can.
At least I was able to fix 169 image CVEs with the current alpine 3.19 ;)

If you can, please build a multi-platform image for Apple Silicon to support the java:docker:arm64 effort.